### PR TITLE
Remove hard-coded database schema

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include CHANGES.rst LICENSE README.rst conftest.py
-recursive-include postgresql_audit *.sql
+recursive-include postgresql_audit/templates *.sql
 recursive-exclude postgresql_audit *.pyc
 recursive-include tests *
 recursive-exclude tests *.pyc

--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -3,7 +3,7 @@ Migrations
 
 Usually your schema changes over time. The schema of PostgreSQL-Audit is very flexible, since it stores the data in JSONB columns. Your schema can change without the need of changing the version history JSONB data columns.
 
-However in case you want to show the version history on the application side you may want to reflect the changes you make to your schema to `old_data` and `changed_data` columns of `audit.activity` table. The other solution is to make your application code aware of all the schema changes that have happened over time. This can get a bit tedious if your schema is quickly evolving.
+However in case you want to show the version history on the application side you may want to reflect the changes you make to your schema to `old_data` and `changed_data` columns of `activity` table. The other solution is to make your application code aware of all the schema changes that have happened over time. This can get a bit tedious if your schema is quickly evolving.
 
 
 Changing column name

--- a/postgresql_audit/base.py
+++ b/postgresql_audit/base.py
@@ -1,4 +1,5 @@
 import os
+import string
 import warnings
 from contextlib import contextmanager
 from datetime import timedelta
@@ -58,32 +59,10 @@ def assign_actor(base, cls, actor_cls):
         cls.actor_id = sa.Column(sa.Text)
 
 
-def audit_table(table, exclude_columns=None):
-    args = [table.name]
-    if exclude_columns:
-        for column in exclude_columns:
-            if column not in table.c:
-                raise ImproperlyConfigured(
-                    "Could not configure versioning. Table '{}'' does "
-                    "not have a column named '{}'.".format(
-                        table.name, column
-                    )
-                )
-        args.append(array(exclude_columns))
-
-    query = sa.select(
-        [sa.func.audit.audit_table(*args)]
-    )
-    if query not in cached_statements:
-        cached_statements[query] = StatementExecutor(query)
-    listener = (table, 'after_create', cached_statements[query])
-    if not sa.event.contains(*listener):
-        sa.event.listen(*listener)
-
-
-def activity_base(base):
+def activity_base(base, schema=None):
     class ActivityBase(base):
         __abstract__ = True
+        __table_args__ = {'schema': schema}
         id = sa.Column(sa.BigInteger, primary_key=True)
         schema_name = sa.Column(sa.Text)
         table_name = sa.Column(sa.Text)
@@ -133,27 +112,12 @@ def convert_callables(values):
 
 
 class VersioningManager(object):
-    table_listeners = [
-        (
-            'before_create',
-            sa.schema.DDL(read_file('schema.sql')),
-        ),
-        (
-            'after_create',
-            sa.schema.DDL(
-                read_file('create_activity.sql').replace('%', '%%') +
-                read_file('audit_table.sql').replace('%', '%%')
-            )
-        ),
-        (
-            'after_drop',
-            sa.schema.DDL('DROP SCHEMA audit CASCADE')
-        )
-    ]
+    _actor_cls = None
 
-    def __init__(self, actor_cls=None):
+    def __init__(self, actor_cls=None, schema_name=None):
+        if actor_cls is not None:
+            self._actor_cls = actor_cls
         self.values = {}
-        self._actor_cls = actor_cls
         self.listeners = (
             (
                 orm.mapper,
@@ -171,11 +135,13 @@ class VersioningManager(object):
                 self.receive_after_flush,
             ),
         )
+        self.schema_name = schema_name
+        self.table_listener_mapping = self.get_table_listener_mapping()
+        self.table_listeners = list(self.table_listener_mapping.items())
         self.pending_classes = WeakSet()
         self.cached_ddls = {}
 
-    @property
-    def transaction_values(self):
+    def get_transaction_values(self):
         return self.values
 
     @contextmanager
@@ -189,6 +155,66 @@ class VersioningManager(object):
             current_setting,
         ))
 
+    def render_tmpl(self, tmpl_name):
+        file_contents = read_file(
+            'templates/{}'.format(tmpl_name)
+        ).replace('%', '%%')
+        tmpl = string.Template(file_contents)
+        context = dict(schema_name=self.schema_name)
+
+        if self.schema_name is None:
+            context['schema_prefix'] = ''
+            context['revoke_cmd'] = ''
+        else:
+            context['schema_prefix'] = '{}.'.format(self.schema_name)
+            context['revoke_cmd'] = (
+                'REVOKE ALL ON {schema_prefix}activity FROM public;'
+            ).format(**context)
+
+        return tmpl.substitute(**context)
+
+    def get_table_listener_mapping(self):
+        mapping = {
+            'after_create': sa.schema.DDL(
+                self.render_tmpl('create_activity.sql') +
+                self.render_tmpl('audit_table_func.sql')
+            ),
+        }
+        if self.schema_name is not None:
+            mapping.update({
+                'before_create': sa.schema.DDL(
+                    self.render_tmpl('create_schema.sql')
+                ),
+                'after_drop': sa.schema.DDL(
+                    self.render_tmpl('drop_schema.sql')
+                ),
+            })
+        return mapping
+
+    def audit_table(self, table, exclude_columns=None):
+        args = [table.name]
+        if exclude_columns:
+            for column in exclude_columns:
+                if column not in table.c:
+                    raise ImproperlyConfigured(
+                        "Could not configure versioning. Table '{}'' does "
+                        "not have a column named '{}'.".format(
+                            table.name, column
+                        )
+                    )
+            args.append(array(exclude_columns))
+
+        if self.schema_name is None:
+            func = sa.func.audit_table
+        else:
+            func = getattr(getattr(sa.func, self.schema_name), 'audit_table')
+        query = sa.select([func(*args)])
+        if query not in cached_statements:
+            cached_statements[query] = StatementExecutor(query)
+        listener = (table, 'after_create', cached_statements[query])
+        if not sa.event.contains(*listener):
+            sa.event.listen(*listener)
+
     def set_activity_values(self, session):
         dialect = session.bind.engine.dialect
         table = self.activity_cls.__table__
@@ -199,8 +225,9 @@ class VersioningManager(object):
                           RuntimeWarning)
             return
 
-        if self.values:
-            values = convert_callables(self.transaction_values)
+        values = convert_callables(self.get_transaction_values())
+
+        if values:
             stmt = (
                 table
                 .update()
@@ -235,7 +262,7 @@ class VersioningManager(object):
         instrumentation process.
         """
         for cls in self.pending_classes:
-            audit_table(cls.__table__, cls.__versioned__.get('exclude'))
+            self.audit_table(cls.__table__, cls.__versioned__.get('exclude'))
         assign_actor(self.base, self.activity_cls, self.actor_cls)
 
     def attach_table_listeners(self):
@@ -281,9 +308,8 @@ class VersioningManager(object):
             sa.event.remove(*listener)
 
     def activity_model_factory(self, base):
-        class Activity(activity_base(base)):
+        class Activity(activity_base(base, self.schema_name)):
             __tablename__ = 'activity'
-            __table_args__ = {'schema': 'audit'}
 
         return Activity
 

--- a/postgresql_audit/migrations.py
+++ b/postgresql_audit/migrations.py
@@ -4,7 +4,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 from .expressions import jsonb_change_key_name, jsonb_merge
 
 
-def get_activity_table():
+def get_activity_table(schema=None):
     return sa.Table(
         'activity',
         sa.MetaData(),
@@ -13,11 +13,11 @@ def get_activity_table():
         sa.Column('verb', sa.String),
         sa.Column('old_data', JSONB),
         sa.Column('changed_data', JSONB),
-        schema='audit',
+        schema=schema,
     )
 
 
-def alter_column(conn, table, column_name, func):
+def alter_column(conn, table, column_name, func, schema=None):
     """
     Run given callable against given table and given column in activity table
     jsonb data columns. This function is useful when you want to reflect type
@@ -59,8 +59,10 @@ def alter_column(conn, table, column_name, func):
         A callable to run against specific column in activity table jsonb data
         columns. The callable should take two parameters the jsonb value
         corresponding to given column_name and activity table object.
+    :param schema:
+        Optional name of schema to use.
     """
-    activity_table = get_activity_table()
+    activity_table = get_activity_table(schema=schema)
     query = (
         activity_table
         .update()
@@ -91,9 +93,10 @@ def alter_column(conn, table, column_name, func):
     return conn.execute(query)
 
 
-def change_column_name(conn, table, old_column_name, new_column_name):
+def change_column_name(conn, table, old_column_name, new_column_name,
+                       schema=None):
     """
-    Changes given audit.activity jsonb data column key. This function is useful
+    Changes given `activity` jsonb data column key. This function is useful
     when you want to reflect column name changes to activity table.
 
     ::
@@ -121,8 +124,10 @@ def change_column_name(conn, table, old_column_name, new_column_name):
         Name of the column to change
     :param new_column_name:
         New colum name
+    :param schema:
+        Optional name of schema to use.
     """
-    activity_table = get_activity_table()
+    activity_table = get_activity_table(schema=schema)
     query = (
         activity_table
         .update()
@@ -143,9 +148,9 @@ def change_column_name(conn, table, old_column_name, new_column_name):
     return conn.execute(query)
 
 
-def add_column(conn, table, column_name, default_value=None):
+def add_column(conn, table, column_name, default_value=None, schema=None):
     """
-    Adds given column to `audit.activity` table jsonb data columns.
+    Adds given column to `activity` table jsonb data columns.
 
     In the following example we reflect the changes made to our schema to
     activity table.
@@ -171,8 +176,10 @@ def add_column(conn, table, column_name, default_value=None):
         Name of the column to add
     :param default_value:
         The default value of the column
+    :param schema:
+        Optional name of schema to use.
     """
-    activity_table = get_activity_table()
+    activity_table = get_activity_table(schema=schema)
     data = {column_name: default_value}
     query = (
         activity_table
@@ -211,9 +218,9 @@ def add_column(conn, table, column_name, default_value=None):
     return conn.execute(query)
 
 
-def remove_column(conn, table, column_name):
+def remove_column(conn, table, column_name, schema=None):
     """
-    Removes given audit.activity jsonb data column key. This function is useful
+    Removes given `activity` jsonb data column key. This function is useful
     when you are doing schema changes that require removing a column.
 
     Let's say you've been using PostgreSQL-Audit for a while for a table called
@@ -238,8 +245,10 @@ def remove_column(conn, table, column_name):
         The table to remove the column from
     :param column_name:
         Name of the column to remove
+    :param schema:
+        Optional name of schema to use.
     """
-    activity_table = get_activity_table()
+    activity_table = get_activity_table(schema=schema)
     remove = sa.cast(column_name, sa.Text)
     query = (
         activity_table

--- a/postgresql_audit/schema.sql
+++ b/postgresql_audit/schema.sql
@@ -1,4 +1,0 @@
-CREATE SCHEMA audit;
-REVOKE ALL ON SCHEMA audit FROM public;
-
-COMMENT ON SCHEMA audit IS 'Out-of-table audit/history logging tables and trigger functions';

--- a/postgresql_audit/templates/activity.sql
+++ b/postgresql_audit/templates/activity.sql
@@ -16,7 +16,7 @@
 -- you're interested in, into a temporary table where you CREATE any useful
 -- indexes and do your analysis.
 --
-CREATE TABLE audit.activity (
+CREATE TABLE ${schema_prefix}activity (
     id BIGSERIAL primary key,
     schema_name TEXT,
     table_name TEXT,
@@ -32,4 +32,4 @@ CREATE TABLE audit.activity (
     changed_data JSONB
 );
 
-REVOKE ALL ON audit.activity FROM public;
+${revoke_cmd}

--- a/postgresql_audit/templates/audit_table_func.sql
+++ b/postgresql_audit/templates/audit_table_func.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION audit.audit_table(target_table regclass, ignored_cols text[]) RETURNS void AS $body$
+CREATE OR REPLACE FUNCTION ${schema_prefix}audit_table(target_table regclass, ignored_cols text[]) RETURNS void AS $$body$$
 DECLARE
     stm_targets text = 'INSERT OR UPDATE OR DELETE OR TRUNCATE';
     _q_txt text;
@@ -14,30 +14,30 @@ BEGIN
              target_table || ' FOR EACH ROW ' ||
              E'WHEN (current_setting(\'session_replication_role\') ' ||
              E'<> \'local\')' ||
-             ' EXECUTE PROCEDURE audit.create_activity(' ||
+             ' EXECUTE PROCEDURE ${schema_prefix}create_activity(' ||
              _ignored_cols_snip ||
              ');';
     RAISE NOTICE '%',_q_txt;
     EXECUTE _q_txt;
     stm_targets = 'TRUNCATE';
 END;
-$body$
+$$body$$
 language 'plpgsql';
 
-COMMENT ON FUNCTION audit.audit_table(regclass, text[]) IS $body$
+COMMENT ON FUNCTION ${schema_prefix}audit_table(regclass, text[]) IS $$body$$
 Add auditing support to a table.
 
 Arguments:
    target_table:     Table name, schema qualified if not on search_path
    ignored_cols:     Columns to exclude from update diffs, ignore updates that change only ignored cols.
-$body$;
+$$body$$;
 
 
-CREATE OR REPLACE FUNCTION audit.audit_table(target_table regclass) RETURNS void AS $body$
-SELECT audit.audit_table($1, ARRAY[]::text[]);
-$body$ LANGUAGE SQL;
+CREATE OR REPLACE FUNCTION ${schema_prefix}audit_table(target_table regclass) RETURNS void AS $$body$$
+SELECT ${schema_prefix}audit_table($$1, ARRAY[]::text[]);
+$$body$$ LANGUAGE SQL;
 
 
-COMMENT ON FUNCTION audit.audit_table(regclass) IS $body$
+COMMENT ON FUNCTION ${schema_prefix}audit_table(regclass) IS $$body$$
 Add auditing support to the given table. Row-level changes will be logged with full client query text. No cols are ignored.
-$body$;
+$$body$$;

--- a/postgresql_audit/templates/create_schema.sql
+++ b/postgresql_audit/templates/create_schema.sql
@@ -1,0 +1,4 @@
+CREATE SCHEMA ${schema_name};
+REVOKE ALL ON SCHEMA ${schema_name} FROM public;
+
+COMMENT ON SCHEMA ${schema_name} IS 'Out-of-table audit/history logging tables and trigger functions';

--- a/postgresql_audit/templates/drop_schema.sql
+++ b/postgresql_audit/templates/drop_schema.sql
@@ -1,0 +1,1 @@
+DROP SCHEMA ${schema_name} CASCADE;

--- a/tests/test_custom_schema.py
+++ b/tests/test_custom_schema.py
@@ -1,0 +1,186 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.ext.declarative import declarative_base
+
+from postgresql_audit import VersioningManager
+
+from .utils import last_activity
+
+
+@pytest.fixture()
+def schema_name():
+    return 'audit'
+
+
+@pytest.fixture()
+def versioning_manager(schema_name):
+    return VersioningManager(schema_name=schema_name)
+
+
+@pytest.yield_fixture()
+def activity_cls(base, versioning_manager):
+    versioning_manager.init(base)
+    yield versioning_manager.activity_cls
+    versioning_manager.remove_listeners()
+
+
+@pytest.yield_fixture()
+def table_creator(
+        base,
+        connection,
+        session,
+        models,
+        versioning_manager,
+        schema_name
+):
+    sa.orm.configure_mappers()
+    connection.execute('DROP SCHEMA IF EXISTS {} CASCADE'.format(schema_name))
+    tx = connection.begin()
+    versioning_manager.activity_cls.__table__.create(connection)
+    base.metadata.create_all(connection)
+    tx.commit()
+    yield
+    base.metadata.drop_all(connection)
+    session.commit()
+
+
+@pytest.mark.usefixtures('activity_cls', 'table_creator')
+class TestCustomSchemaActivityCreation(object):
+
+    def test_insert(self, user, connection, schema_name):
+        activity = last_activity(connection, schema=schema_name)
+        assert activity['old_data'] is None
+        assert activity['changed_data'] == {
+            'id': user.id,
+            'name': 'John',
+            'age': 15
+        }
+        assert activity['table_name'] == 'user'
+        assert activity['transaction_id'] > 0
+        assert activity['verb'] == 'insert'
+
+    def test_operation_after_commit(
+        self,
+        activity_cls,
+        user_class,
+        session
+    ):
+        user = user_class(name='Jack')
+        session.add(user)
+        session.commit()
+        user = user_class(name='Jack')
+        session.add(user)
+        session.commit()
+        assert session.query(activity_cls).count() == 2
+
+    def test_operation_after_rollback(
+        self,
+        activity_cls,
+        user_class,
+        session
+    ):
+        user = user_class(name='John')
+        session.add(user)
+        session.rollback()
+        user = user_class(name='John')
+        session.add(user)
+        session.commit()
+        assert session.query(activity_cls).count() == 1
+
+    def test_manager_defaults(
+        self,
+        user_class,
+        session,
+        versioning_manager,
+        schema_name
+    ):
+        versioning_manager.values = {'actor_id': 1}
+        user = user_class(name='John')
+        session.add(user)
+        session.commit()
+        activity = last_activity(session, schema=schema_name)
+        assert activity['actor_id'] == '1'
+
+    def test_callables_as_manager_defaults(
+        self,
+        user_class,
+        session,
+        versioning_manager,
+        schema_name
+    ):
+        versioning_manager.values = {'actor_id': lambda: 1}
+        user = user_class(name='John')
+        session.add(user)
+        session.commit()
+        activity = last_activity(session, schema=schema_name)
+        assert activity['actor_id'] == '1'
+
+    def test_raw_inserts(
+        self,
+        user_class,
+        session,
+        versioning_manager,
+        schema_name
+    ):
+        versioning_manager.values = {'actor_id': 1}
+        session.execute(user_class.__table__.insert().values(name='John'))
+        session.execute(user_class.__table__.insert().values(name='John'))
+        versioning_manager.set_activity_values(session)
+        activity = last_activity(session, schema=schema_name)
+
+        assert activity['actor_id'] == '1'
+
+    def test_activity_repr(self, activity_cls):
+        assert repr(activity_cls(id=3, table_name='user')) == (
+            "<Activity table_name='user' id=3>"
+        )
+
+    def test_custom_actor_class(self, user_class, schema_name):
+        manager = VersioningManager(
+            actor_cls=user_class,
+            schema_name=schema_name
+        )
+        manager.init(declarative_base())
+        sa.orm.configure_mappers()
+        assert isinstance(
+            manager.activity_cls.actor_id.property.columns[0].type,
+            sa.Integer
+        )
+        assert manager.activity_cls.actor
+        manager.remove_listeners()
+
+    def test_data_expression_sql(self, activity_cls):
+        assert str(activity_cls.data) == (
+            'jsonb_merge(audit.activity.old_data, audit.activity.changed_data)'
+        )
+
+    def test_data_expression(self, user, session, activity_cls):
+        user.name = 'Luke'
+        session.commit()
+        assert session.query(activity_cls).filter(
+            activity_cls.table_name == 'user',
+            activity_cls.data['id'].cast(sa.Integer) == user.id
+        ).count() == 2
+
+    def test_custom_string_actor_class(self, schema_name):
+        base = declarative_base()
+
+        class User(base):
+            __tablename__ = 'user'
+            id = sa.Column(sa.Integer, primary_key=True)
+
+        User()
+        manager = VersioningManager(
+            actor_cls='User',
+            schema_name=schema_name
+        )
+        manager.init(base)
+        sa.orm.configure_mappers()
+        assert isinstance(
+            manager.activity_cls.actor_id.property.columns[0].type,
+            sa.Integer
+        )
+        assert manager.activity_cls.actor
+        manager.remove_listeners()

--- a/tests/test_migration_functions.py
+++ b/tests/test_migration_functions.py
@@ -5,8 +5,7 @@ from postgresql_audit import (
     add_column,
     alter_column,
     change_column_name,
-    remove_column,
-    versioning_manager
+    remove_column
 )
 
 from .utils import last_activity
@@ -19,7 +18,8 @@ class TestChangeColumnName(object):
         session,
         article,
         user,
-        connection
+        connection,
+        versioning_manager
     ):
         change_column_name(connection, 'user', 'name', 'some_name')
         activity = session.query(versioning_manager.activity_cls).filter_by(
@@ -55,7 +55,8 @@ class TestRemoveColumn(object):
         session,
         article,
         user,
-        connection
+        connection,
+        versioning_manager
     ):
         remove_column(connection, 'user', 'name')
         activity = session.query(versioning_manager.activity_cls).filter_by(
@@ -90,7 +91,8 @@ class TestAddColumn(object):
         session,
         article,
         user,
-        connection
+        connection,
+        versioning_manager
     ):
         add_column(connection, 'user', 'some_column')
         activity = session.query(versioning_manager.activity_cls).filter_by(
@@ -130,7 +132,8 @@ class TestAlterColumn(object):
         session,
         article,
         user,
-        connection
+        connection,
+        versioning_manager
     ):
         alter_column(
             connection,

--- a/tests/test_sql_files.py
+++ b/tests/test_sql_files.py
@@ -9,7 +9,7 @@ def activity_values(session):
     session.execute(
         '''CREATE TEMP TABLE activity_values
         ON COMMIT DELETE ROWS AS
-        SELECT * FROM audit.activity WHERE 1 = 2
+        SELECT * FROM activity WHERE 1 = 2
         '''
     )
     yield
@@ -72,7 +72,7 @@ class TestActivityCreation(object):
         ('field', 'value'),
         (
             ('target_id', '1'),
-            ('actor_id', '1')
+            ('actor_id', '1'),
         )
     )
     def test_custom_fields(self, activity_values, session, user, field, value):
@@ -92,7 +92,7 @@ class TestActivityCreationWithColumnExclusion(object):
     @pytest.fixture
     def audit_trigger_creator(self, session, user_class):
         session.execute(
-            '''SELECT audit.audit_table('{0}', '{{"age"}}')'''.format(
+            '''SELECT audit_table('{0}', '{{"age"}}')'''.format(
                 user_class.__tablename__
             )
         )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,11 @@
-def last_activity(connection):
+def last_activity(connection, schema=None):
+    if schema is not None:
+        schema_prefix = '{}.'.format(schema)
+    else:
+        schema_prefix = ''
     return dict(
         connection.execute(
-            'SELECT * FROM audit.activity ORDER BY issued_at DESC LIMIT 1'
+            'SELECT * FROM {}activity ORDER BY issued_at '
+            'DESC LIMIT 1'.format(schema_prefix)
         ).fetchone()
     )


### PR DESCRIPTION
Makes the code more portable by defaulting to not using a separate schema. In response to the discussion in #3.