### PR TITLE
The HSTORE extension shouldn't be needed anymore in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ addons:
 
 before_script:
   - psql -c 'create database postgresql_audit_test;' -U postgres
-  - psql -c 'create extension hstore;' -U postgres -d postgresql_audit_test
 
 language: python
 python:


### PR DESCRIPTION
At least not according to the v0.4.0 changelog https://github.com/kvesteri/postgresql-audit/blob/master/CHANGES.rst#040-2015-03-12