### PR TITLE
Temporarily disable inserts to the activity table

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import os
 import pytest
 import sqlalchemy as sa
 from sqlalchemy import create_engine
@@ -9,8 +10,18 @@ from postgresql_audit import versioning_manager
 
 
 @pytest.fixture()
-def dns():
-    return 'postgres://postgres@localhost/postgresql_audit_test'
+def db_user():
+    return os.environ.get('POSTGRESQL_AUDIT_TEST_USER', 'postgres')
+
+
+@pytest.fixture()
+def db_name():
+    return os.environ.get('POSTGRESQL_AUDIT_TEST_DB', 'postgresql_audit_test')
+
+
+@pytest.fixture()
+def dns(db_user, db_name):
+    return 'postgres://{}@localhost/{}'.format(db_user, db_name)
 
 
 @pytest.fixture()

--- a/docs/sqlalchemy.rst
+++ b/docs/sqlalchemy.rst
@@ -158,3 +158,16 @@ Hence you can get the desired activities as follows:
 
 
 .. _hybrid_property: http://docs.sqlalchemy.org/en/latest/orm/extensions/hybrid.html?highlight=hybrid#sqlalchemy.ext.hybrid.hybrid_property
+
+
+Temporarily disabling inserts to the `activity` table
+-----------------------------------------------------
+
+There are cases where you might not want to track changes to your data, such as when doing big changes to a table. In those cases you can use the `VersioningManager.disable` context manager.
+
+.. code-block:: python
+
+    with versioning_manager.disable(session):
+        for i in range(1, 10000):
+            db.session.add(db.Product(name='Product %s' % i))
+        db.session.commit()

--- a/postgresql_audit/audit_table.sql
+++ b/postgresql_audit/audit_table.sql
@@ -11,8 +11,10 @@ BEGIN
         _ignored_cols_snip = ', ' || quote_literal(ignored_cols);
     END IF;
     _q_txt = 'CREATE TRIGGER audit_trigger_row AFTER INSERT OR UPDATE OR DELETE ON ' ||
-             target_table ||
-             ' FOR EACH ROW EXECUTE PROCEDURE audit.create_activity(' ||
+             target_table || ' FOR EACH ROW ' ||
+             E'WHEN (current_setting(\'session_replication_role\') ' ||
+             E'<> \'local\')' ||
+             ' EXECUTE PROCEDURE audit.create_activity(' ||
              _ignored_cols_snip ||
              ');';
     RAISE NOTICE '%',_q_txt;

--- a/postgresql_audit/base.py
+++ b/postgresql_audit/base.py
@@ -1,4 +1,5 @@
 import os
+from contextlib import contextmanager
 from datetime import timedelta
 from weakref import WeakSet
 
@@ -174,6 +175,17 @@ class VersioningManager(object):
     @property
     def transaction_values(self):
         return self.values
+
+    @contextmanager
+    def disable(self, session):
+        current_setting = session.execute(
+            "SELECT current_setting('session_replication_role')"
+        ).fetchone().current_setting
+        session.execute('SET LOCAL session_replication_role = "local"')
+        yield
+        session.execute('SET LOCAL session_replication_role = "{}"'.format(
+            current_setting,
+        ))
 
     def set_activity_values(self, session):
         table = self.activity_cls.__table__

--- a/tests/test_sqlalchemy_integration.py
+++ b/tests/test_sqlalchemy_integration.py
@@ -134,6 +134,23 @@ class TestActivityCreation(object):
         )
         assert manager.activity_cls.actor
 
+    def test_disable_contextmanager(
+        self,
+        activity_cls,
+        user_class,
+        session
+    ):
+        with versioning_manager.disable(session):
+            user = user_class(name='Jack')
+            session.add(user)
+            session.commit()
+        assert session.query(activity_cls).count() == 0
+
+        user = user_class(name='Jack')
+        session.add(user)
+        session.commit()
+        assert session.query(activity_cls).count() == 1
+
 
 @pytest.mark.usefixtures('activity_cls', 'table_creator')
 class TestColumnExclusion(object):


### PR DESCRIPTION
There are cases where you might not want to track changes to your data, such as when doing big changes to a table. In those cases you can use the `VersioningManager.disable` context manager.

Usage:

```python
with versioning_manager.disable(session):
    for i in range(1, 10000):
        db.session.add(db.Product(name='Product %s' % i))
    db.session.commit()
```

Note that this PR includes changes from #4. https://github.com/kvesteri/postgresql-audit/commit/607f06e38161a8c2c6a0ef1e9065dc06894fa898 contains the changes that touch this feature.

Inspiration found @ http://blog.endpoint.com/2015/07/selectively-firing-postgres-triggers.html