### PR TITLE
Make sure that tests run on SQLAlchemy>=1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
+sudo: false
+dist: trusty
 addons:
-  postgresql: "9.4"
+  postgresql: 9.5
 
 before_script:
   - psql -c 'create database postgresql_audit_test;' -U postgres
@@ -10,19 +12,19 @@ matrix:
   include:
   - python: 2.7
     env:
-      - "TOXENV=py27"
+      - TOXENV='py-sqla{0.9,1.0,1.1}'
   - python: 3.3
     env:
-      - "TOXENV=py33"
+      - TOXENV='py-sqla{0.9,1.0,1.1}'
   - python: 3.4
     env:
-      - "TOXENV=py34"
+      - TOXENV='py-sqla{0.9,1.0,1.1}'
   - python: 3.5
     env:
-      - "TOXENV=py35"
+      - TOXENV='py-sqla{0.9,1.0,1.1}'
   - python: 3.5
     env:
-      - "TOXENV=lint"
+      - TOXENV='lint'
 
 install:
   - pip install tox

--- a/docs/sqlalchemy.rst
+++ b/docs/sqlalchemy.rst
@@ -151,7 +151,7 @@ Hence you can get the desired activities as follows:
 
     activities = session.query(Activity).filter(
         Activity.table_name == 'article',
-        Activity.data['id'].cast(db.Integer) == 3
+        Activity.data['id'].astext.cast(db.Integer) == 3
     )
 
 

--- a/tests/test_custom_schema.py
+++ b/tests/test_custom_schema.py
@@ -153,7 +153,7 @@ class TestCustomSchemaactivityCreation(object):
         manager.remove_listeners()
 
     def test_data_expression_sql(self, activity_cls):
-        assert str(activity_cls.data) == (
+        assert str(activity_cls.data.expression) == (
             'jsonb_merge(audit.activity.old_data, '
             'audit.activity.changed_data)'
         )
@@ -163,7 +163,7 @@ class TestCustomSchemaactivityCreation(object):
         session.commit()
         assert session.query(activity_cls).filter(
             activity_cls.table_name == 'user',
-            activity_cls.data['id'].cast(sa.Integer) == user.id
+            activity_cls.data['id'].astext.cast(sa.Integer) == user.id
         ).count() == 2
 
     def test_custom_string_actor_class(self, schema_name):

--- a/tests/test_sqlalchemy_integration.py
+++ b/tests/test_sqlalchemy_integration.py
@@ -113,7 +113,7 @@ class TestActivityCreation(object):
         manager.remove_listeners()
 
     def test_data_expression_sql(self, activity_cls):
-        assert str(activity_cls.data) == (
+        assert str(activity_cls.data.expression) == (
             'jsonb_merge(activity.old_data, activity.changed_data)'
         )
 
@@ -122,7 +122,7 @@ class TestActivityCreation(object):
         session.commit()
         assert session.query(activity_cls).filter(
             activity_cls.table_name == 'user',
-            activity_cls.data['id'].cast(sa.Integer) == user.id
+            activity_cls.data['id'].astext.cast(sa.Integer) == user.id
         ).count() == 2
 
     def test_custom_string_actor_class(self):

--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,16 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py33, py34, py35, lint
+envlist = {py27,py33,py34,py35}-sqla{0.9,1.0,1.1}, lint
 
 [testenv]
 commands =
     py.test postgresql_audit tests
 deps =
     -rrequirements_test.txt
+    sqla0.9: SQLAlchemy>=0.9.4,<1.0
+    sqla1.0: SQLAlchemy>=1.0,<1.1
+    sqla1.1: SQLAlchemy>=1.1,<1.2
 passenv = POSTGRESQL_AUDIT_TEST_USER POSTGRESQL_AUDIT_TEST_DB
 
 [testenv:py27]


### PR DESCRIPTION
Why `.astext` is needed: http://docs.sqlalchemy.org/en/latest/changelog/migration_11.html#the-json-cast-operation-now-requires-astext-is-called-explicitly

*Probably* why `.expression` is needed: http://docs.sqlalchemy.org/en/latest/changelog/migration_11.html#hybrid-properties-and-methods-now-propagate-the-docstring-as-well-as-info