### PR TITLE
Drop and create jsonb_substract function instead of replacing it

### DIFF
--- a/postgresql_audit/templates/operators.sql
+++ b/postgresql_audit/templates/operators.sql
@@ -1,5 +1,6 @@
 -- http://coussej.github.io/2016/05/24/A-Minus-Operator-For-PostgreSQLs-JSONB/
-CREATE OR REPLACE FUNCTION jsonb_subtract(arg1 jsonb, arg2 jsonb)
+DROP FUNCTION IF EXISTS jsonb_subtract(jsonb,jsonb) CASCADE;
+CREATE FUNCTION jsonb_subtract(arg1 jsonb, arg2 jsonb)
 RETURNS jsonb AS $$
 SELECT
   COALESCE(json_object_agg(key, value), '{}')::jsonb


### PR DESCRIPTION
This solves an issue we were running into after migrating our postgresql db from 9.6 to 10: 
```
(psycopg2.ProgrammingError) cannot change name of input parameter "json"
HINT:  Use DROP FUNCTION jsonb_subtract(jsonb,jsonb) first.
```