### PR TITLE
Make sure that issues_at is stored at UTC timezone

### DIFF
--- a/postgresql_audit/base.py
+++ b/postgresql_audit/base.py
@@ -274,7 +274,7 @@ class VersioningManager(object):
         values = convert_callables(self.get_transaction_values())
         if values:
             values['native_transaction_id'] = sa.func.txid_current()
-            values['issued_at'] = sa.func.now()
+            values['issued_at'] = sa.text("now() AT TIME ZONE 'UTC'")
             stmt = (
                 table
                 .insert()

--- a/postgresql_audit/templates/create_activity.sql
+++ b/postgresql_audit/templates/create_activity.sql
@@ -19,7 +19,7 @@ BEGIN
     audit_row.schema_name = TG_TABLE_SCHEMA::text;
     audit_row.table_name = TG_TABLE_NAME::text;
     audit_row.relid = TG_RELID;
-    audit_row.issued_at = statement_timestamp();
+    audit_row.issued_at = statement_timestamp() AT TIME ZONE 'UTC';
     audit_row.native_transaction_id = txid_current();
     audit_row.transaction_id = (
         SELECT id


### PR DESCRIPTION
I have one project where the test suite fails on my development environment because postgres-audit is storing the `issued_at` using my development environments local timezone, and one of the tests catches this issue. On CI and in production environments the DB is on UTC timezone, so we didn't experience this issue there.

I'd assume that all times that are stored to the DB are using UTC timezone.