### PR TITLE
fix: use a finally block for 'disable'

### DIFF
--- a/postgresql_audit/base.py
+++ b/postgresql_audit/base.py
@@ -207,10 +207,12 @@ class VersioningManager(object):
         session.execute(
             "SET LOCAL postgresql_audit.enable_versioning = 'false'"
         )
-        yield
-        session.execute(
-            "SET LOCAL postgresql_audit.enable_versioning = 'true'"
-        )
+        try:
+            yield
+        finally:
+            session.execute(
+                "SET LOCAL postgresql_audit.enable_versioning = 'true'"
+            )
 
     def render_tmpl(self, tmpl_name):
         file_contents = read_file(

--- a/tests/test_sqlalchemy_integration.py
+++ b/tests/test_sqlalchemy_integration.py
@@ -189,8 +189,9 @@ class TestActivityCreation(object):
                 session.add(user)
                 session.commit()
                 raise Exception("I should brake the activity")
-        except:
-            # ignore the raised exception, we just what to make the activity is back
+        except Exception:
+            # ignore the raised exception
+            # we just what to make the activity is back
             pass
 
         assert session.query(activity_cls).count() == 0

--- a/tests/test_sqlalchemy_integration.py
+++ b/tests/test_sqlalchemy_integration.py
@@ -176,6 +176,30 @@ class TestActivityCreation(object):
         session.commit()
         assert session.query(activity_cls).count() == 1
 
+    def test_disable_contextmanager_with_exception(
+        self,
+        activity_cls,
+        user_class,
+        session,
+        versioning_manager
+    ):
+        try:
+            with versioning_manager.disable(session):
+                user = user_class(name='Jack')
+                session.add(user)
+                session.commit()
+                raise Exception("I should brake the activity")
+        except:
+            # ignore the raised exception, we just what to make the activity is back
+            pass
+
+        assert session.query(activity_cls).count() == 0
+
+        user = user_class(name='Jack')
+        session.add(user)
+        session.commit()
+        assert session.query(activity_cls).count() == 1
+
     def test_multiple_flush_within_same_transaction(
         self,
         activity_cls,


### PR DESCRIPTION
If the `yield` in the `disable` function was raising an exception the audit was staying disabled for the rest of the sessions (which can cause issues in long running jobs)