### PR TITLE
Allow nesting activity_values

### DIFF
--- a/postgresql_audit/flask.py
+++ b/postgresql_audit/flask.py
@@ -56,13 +56,27 @@ def context_available():
     )
 
 
+def merge_dicts(a, b):
+    c = copy(a)
+    c.update(b)
+    return c
+
+
 @contextmanager
 def activity_values(**values):
     if not context_available():
         return
+    if hasattr(g, 'activity_values'):
+        previous_value = g.activity_values
+        values = merge_dicts(previous_value, values)
+    else:
+        previous_value = None
     g.activity_values = values
     yield
-    del g.activity_values
+    if previous_value is None:
+        del g.activity_values
+    else:
+        g.activity_values = previous_value
 
 
 versioning_manager = VersioningManager()


### PR DESCRIPTION
I stumbled upon `activity_values` implementation and noticed it does not support nesting.
I see this as a non-breaking change, because currently nesting will raise an error.