### PR TITLE
Specify the column names when inserting new audit rows

### DIFF
--- a/postgresql_audit/templates/create_activity_stmt_level.sql
+++ b/postgresql_audit/templates/create_activity_stmt_level.sql
@@ -19,7 +19,9 @@ BEGIN
     END IF;
 
     IF (TG_OP = 'UPDATE') THEN
-        INSERT INTO ${schema_prefix}activity
+        INSERT INTO ${schema_prefix}activity(
+            id, schema_name, table_name, relid, issued_at, native_transaction_id,
+            verb, old_data, changed_data, transaction_id)
         SELECT
             nextval('${schema_prefix}activity_id_seq') as id,
             TG_TABLE_SCHEMA::text AS schema_name,
@@ -49,7 +51,9 @@ BEGIN
         ) as sub
         WHERE new_data - old_data - excluded_cols != '{}'::jsonb;
     ELSIF (TG_OP = 'INSERT') THEN
-        INSERT INTO ${schema_prefix}activity
+        INSERT INTO ${schema_prefix}activity(
+            id, schema_name, table_name, relid, issued_at, native_transaction_id,
+            verb, old_data, changed_data, transaction_id)
         SELECT
             nextval('${schema_prefix}activity_id_seq') as id,
             TG_TABLE_SCHEMA::text AS schema_name,
@@ -63,7 +67,9 @@ BEGIN
             _transaction_id AS transaction_id
         FROM new_table;
     ELSEIF TG_OP = 'DELETE' THEN
-        INSERT INTO ${schema_prefix}activity
+        INSERT INTO ${schema_prefix}activity(
+            id, schema_name, table_name, relid, issued_at, native_transaction_id,
+            verb, old_data, changed_data, transaction_id)
         SELECT
             nextval('${schema_prefix}activity_id_seq') as id,
             TG_TABLE_SCHEMA::text AS schema_name,

--- a/postgresql_audit/templates/create_activity_stmt_level.sql
+++ b/postgresql_audit/templates/create_activity_stmt_level.sql
@@ -59,7 +59,7 @@ BEGIN
             txid_current() AS native_transaction_id,
             LOWER(TG_OP) AS verb,
             '{}'::jsonb AS old_data,
-            row_to_json(new_table.*)::jsonb - excluded_cols,
+            row_to_json(new_table.*)::jsonb - excluded_cols AS changed_data,
             _transaction_id AS transaction_id
         FROM new_table;
     ELSEIF TG_OP = 'DELETE' THEN


### PR DESCRIPTION
In our project the order of the columns in our database doesn't match the one used by the `INSERT` statements in the `create_activity` function. We noticed this issue as we manually compared our database functions to the ones specified in our SQLAlchemy metadata. This will become an minor issue for us as we're planning to add automated tests for the database schema.