### PR TITLE
Drop support for Pythons that have reached end of their lives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ before_script:
 
 language: python
 python:
-  - 3.5
   - 3.6
   - 3.7
   - 3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ before_script:
 
 language: python
 python:
-  - 2.7
   - 3.5
   - 3.6
   - 3.7

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Here you can see the full list of changes between each PostgreSQL-Audit release.
 0.13.0 (not yet released)
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- **BREAKING CHANGE**: Drop Python 2.7 support. Python 2.7 reached the end of its life on January 1st, 2020.
+- **BREAKING CHANGE**: Drop Python 2.7 and 3.5 support. Python 2.7 reached the end of its life on January 1st, 2020 and Python 3.5 on September 13th, 2020.
 
 0.12.4 (2020-02-18)
 ^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,10 @@ Changelog
 
 Here you can see the full list of changes between each PostgreSQL-Audit release.
 
+0.13.0 (not yet released)
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- **BREAKING CHANGE**: Drop Python 2.7 support. Python 2.7 reached the end of its life on January 1st, 2020.
 
 0.12.4 (2020-02-18)
 ^^^^^^^^^^^^^^^^^^^

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,9 +8,10 @@ Supported platforms
 
 PostgreSQL-Audit has been tested against the following Python platforms.
 
-- cPython 3.3
-- cPython 3.4
 - cPython 3.5
+- cPython 3.6
+- cPython 3.7
+- cPython 3.8
 
 
 Installing an official release

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,7 +8,6 @@ Supported platforms
 
 PostgreSQL-Audit has been tested against the following Python platforms.
 
-- cPython 3.5
 - cPython 3.6
 - cPython 3.7
 - cPython 3.8

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,7 +8,6 @@ Supported platforms
 
 PostgreSQL-Audit has been tested against the following Python platforms.
 
-- cPython 2.7
 - cPython 3.3
 - cPython 3.4
 - cPython 3.5

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,6 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = {py27,py34,py35,py36,py37}-sqla{1.1,1.2,1.3}, lint
+envlist = {py34,py35,py36,py37}-sqla{1.1,1.2,1.3}, lint
 
 [testenv]
 commands =
@@ -15,9 +15,6 @@ deps =
     sqla1.2: SQLAlchemy>=1.2,<1.3
     sqla1.3: SQLAlchemy>=1.3,<1.4
 passenv = POSTGRESQL_AUDIT_TEST_USER POSTGRESQL_AUDIT_TEST_DB
-
-[testenv:py27]
-recreate = True
 
 [testenv:py34]
 recreate = True

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = {py34,py35,py36,py37}-sqla{1.1,1.2,1.3}, lint
+envlist = {py36,py37}-sqla{1.1,1.2,1.3}, lint
 
 [testenv]
 commands =
@@ -15,12 +15,6 @@ deps =
     sqla1.2: SQLAlchemy>=1.2,<1.3
     sqla1.3: SQLAlchemy>=1.3,<1.4
 passenv = POSTGRESQL_AUDIT_TEST_USER POSTGRESQL_AUDIT_TEST_DB
-
-[testenv:py34]
-recreate = True
-
-[testenv:py35]
-recreate = True
 
 [testenv:py36]
 recreate = True


### PR DESCRIPTION
Drop Python 2.7 and 3.5 support. Python 2.7 reached the end of its life on January 1st, 2020 and Python 3.5 on September 13th, 2020.