### PR TITLE
Add support for SQLAlchemy 1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ python:
   - 3.9
 env:
   global:
-    - TOXENV='py-sqla{1.1,1.2,1.3}'
+    - TOXENV='py-sqla{1.1,1.2,1.3,1.4}'
   matrix:
     - POSTGRESQL_VERSION=9.4
     - POSTGRESQL_VERSION=9.5

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Here you can see the full list of changes between each PostgreSQL-Audit release.
 0.13.0 (not yet released)
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Add SQLAlchemy 1.4 support
 - Add Python 3.9 support
 - **BREAKING CHANGE**: Drop Python 2.7 and 3.5 support. Python 2.7 reached the end of its life on January 1st, 2020 and Python 3.5 on September 13th, 2020.
 

--- a/conftest.py
+++ b/conftest.py
@@ -22,7 +22,7 @@ def db_name():
 
 @pytest.fixture
 def dns(db_user, db_name):
-    return 'postgres://{}@localhost/{}'.format(db_user, db_name)
+    return 'postgresql://{}@localhost/{}'.format(db_user, db_name)
 
 
 @pytest.fixture

--- a/postgresql_audit/base.py
+++ b/postgresql_audit/base.py
@@ -408,7 +408,10 @@ class VersioningManager(object):
                     'This manager does not have declarative base set up yet. '
                     'Call init method to set up this manager.'
                 )
-            registry = self.base._decl_class_registry
+            try:
+                registry = self.base.registry._class_registry
+            except AttributeError:  # SQLAlchemy <1.4
+                registry = self.base._decl_class_registry
             try:
                 return registry[self._actor_cls]
             except KeyError:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,6 @@
 flake8>=2.4.0
 Flask-Login==0.2.11
-Flask-SQLAlchemy==2.0
+Flask-SQLAlchemy==2.5.1
 Flask==0.10.1
 flexmock==0.9.7
 isort>=4.2.2

--- a/tests/test_flask_integration.py
+++ b/tests/test_flask_integration.py
@@ -58,6 +58,7 @@ def app(dns, db, login_manager, user_class, article_class):
 
     application = Flask(__name__)
     application.config['SQLALCHEMY_DATABASE_URI'] = dns
+    application.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     application.secret_key = 'secret'
     application.debug = True
     db.init_app(application)

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = {py36,py37,py38,py39}-sqla{1.1,1.2,1.3}, lint
+envlist = {py36,py37,py38,py39}-sqla{1.1,1.2,1.3,1.4}, lint
 
 [testenv]
 commands =
@@ -14,6 +14,7 @@ deps =
     sqla1.1: SQLAlchemy>=1.1,<1.2
     sqla1.2: SQLAlchemy>=1.2,<1.3
     sqla1.3: SQLAlchemy>=1.3,<1.4
+    sqla1.4: SQLAlchemy>=1.4,<1.5
 passenv = POSTGRESQL_AUDIT_TEST_USER POSTGRESQL_AUDIT_TEST_DB
 
 [testenv:py36]


### PR DESCRIPTION
- Add SQLAlchemy 1.4 to test matrices

- Change `postgres` dialect to `postgresql` in tests on SQLAlchemy 1.4 to fix the following exception:

      sqlalchemy.exc.NoSuchModuleError: Can't load plugin: sqlalchemy.dialects:postgres

- Fix `AttributeError: type object 'Base' has no attribute '_decl_class_registry'` error on SQLAlchemy 1.4

- Update Flask-SQLAlchemy to 2.5.1 in tests. Flask-SQLAlchemy 2.5.0 added support for SQLAlchemy 1.4

- Disable `SQLALCHEMY_TRACK_MODIFICATIONS` in tests to suppress the following warnings:

      FSADeprecationWarning: SQLALCHEMY_TRACK_MODIFICATIONS adds significant overhead and will be disabled by default in the future.  Set it to True or False to suppress this warning.