### PR TITLE
Drop support for EOL Python and SQLAlchemy versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
           - name: "Minimum versions"
             python: "3.7"
             postgresql-version: 9.5
-            tox: py-sqla1.1
+            tox: py-sqla1.4
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Here you can see the full list of changes between each PostgreSQL-Audit release.
 Not yet released
 ^^^^^^^^^^^^^^^^
 
+- **BREAKING CHANGE**: Drop support for Python 3.6, which reached the end of its life on December 23rd, 2021.
 - **BREAKING CHANGE**: Drop support for SQLAlchemy 1.1, 1.2 and 1.3, which are no longer maintained.
 
 0.13.0 (2021-05-16)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@ Changelog
 
 Here you can see the full list of changes between each PostgreSQL-Audit release.
 
+Not yet released
+^^^^^^^^^^^^^^^^
+
+- **BREAKING CHANGE**: Drop support for SQLAlchemy 1.1, 1.2 and 1.3, which are no longer maintained.
+
 0.13.0 (2021-05-16)
 ^^^^^^^^^^^^^^^^^^^
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,7 +8,6 @@ Supported platforms
 
 PostgreSQL-Audit has been tested against the following Python platforms.
 
-- cPython 3.6
 - cPython 3.7
 - cPython 3.8
 - cPython 3.9

--- a/postgresql_audit/base.py
+++ b/postgresql_audit/base.py
@@ -408,10 +408,7 @@ class VersioningManager(object):
                     'This manager does not have declarative base set up yet. '
                     'Call init method to set up this manager.'
                 )
-            try:
-                registry = self.base.registry._class_registry
-            except AttributeError:  # SQLAlchemy <1.4
-                registry = self.base._decl_class_registry
+            registry = self.base.registry._class_registry
             try:
                 return registry[self._actor_cls]
             except KeyError:

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'SQLAlchemy>=1.4,<1.5',
         'SQLAlchemy-Utils>=0.29.8'
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
@@ -48,7 +48,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     include_package_data=True,
     platforms='any',
     install_requires=[
-        'SQLAlchemy>=0.9.4',
+        'SQLAlchemy>=1.4,<1.5',
         'SQLAlchemy-Utils>=0.29.8'
     ],
     python_requires='>=3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -4,17 +4,13 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = {py36,py37,py38,py39}-sqla{1.1,1.2,1.3,1.4}, lint
+envlist = {py36,py37,py38,py39}-sqla{1.4}, lint
 
 [testenv]
 commands =
     py.test postgresql_audit tests
 deps =
     -rrequirements_test.txt
-    sqla1.1: SQLAlchemy>=1.1,<1.2
-    sqla1.1: SQLAlchemy-Utils<0.38.3
-    sqla1.2: SQLAlchemy>=1.2,<1.3
-    sqla1.3: SQLAlchemy>=1.3,<1.4
     sqla1.4: SQLAlchemy>=1.4,<1.5
 passenv =
     POSTGRESQL_AUDIT_TEST_USER

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = {py36,py37,py38,py39}-sqla{1.4}, lint
+envlist = {py37,py38,py39}-sqla{1.4}, lint
 
 [testenv]
 commands =
@@ -16,9 +16,6 @@ passenv =
     POSTGRESQL_AUDIT_TEST_USER
     POSTGRESQL_AUDIT_TEST_PASSWORD
     POSTGRESQL_AUDIT_TEST_DB
-
-[testenv:py36]
-recreate = True
 
 [testenv:lint]
 recreate = True


### PR DESCRIPTION
- Drop support for Python 3.6, which reached the end of its life on December 23rd, 2021. See https://endoflife.date/python.

- Drop support for SQLAlchemy 1.1, 1.2 and 1.3 which are longer maintained. See https://www.sqlalchemy.org/download.html#versions
