### PR TITLE
Pin isort and flake8 versions

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,5 +2,4 @@
 known_first_party=postgresql_audit,tests
 line_length=79
 multi_line_output=3
-not_skip=__init__.py
 order_by_type=false

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,7 +3,6 @@ Flask-Login==0.2.11
 Flask-SQLAlchemy==2.5.1
 Flask==0.10.1
 flexmock==0.9.7
-isort>=4.2.2
 itsdangerous==0.24
 MarkupSafe==0.23
 psycopg2>=2.4.6

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,3 @@
-flake8>=2.4.0
 Flask-Login==0.2.11
 Flask-SQLAlchemy==2.5.1
 Flask==0.10.1

--- a/tox.ini
+++ b/tox.ini
@@ -28,9 +28,9 @@ recreate = True
 recreate = True
 commands =
     flake8 postgresql_audit tests
-    isort --verbose --recursive --diff postgresql_audit
-    isort --verbose --recursive --check-only postgresql_audit
+    isort --verbose --diff postgresql_audit
+    isort --verbose --check-only postgresql_audit
 skip_install = True
 deps =
     flake8>=2.5.0
-    isort>=4.2.2
+    isort==5.11.2

--- a/tox.ini
+++ b/tox.ini
@@ -32,5 +32,5 @@ commands =
     isort --verbose --check-only postgresql_audit
 skip_install = True
 deps =
-    flake8>=2.5.0
+    flake8==6.0.0
     isort==5.11.2


### PR DESCRIPTION
- Pin the isort version and fix the deprecation warnings from isort 5.0.0:

	    W0503: Deprecated config options were used: not_skip. Please see the
	    5.0.0 upgrade guide: https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0.html
	
	    W0501: The following deprecated CLI flags were used and ignored:
	    --recursive!
	
	    W0500: Please see the 5.0.0 Upgrade guide:
	    https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0.html

- Pin flake8 to 6.0.0