### PR TITLE
Fix deprecation warnings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Not yet released
 - **BREAKING CHANGE**: Drop support for Python 3.6, which reached the end of its life on December 23rd, 2021.
 - **BREAKING CHANGE**: Drop support for SQLAlchemy 1.1, 1.2 and 1.3, which are no longer maintained.
 - Fix ``SAWarning`` from SQLAlchemy 1.4 about missing ``inherit_cache`` attribute
+- Fix deprecation warnings from Flask 2.2 about ``_app_ctx_stack.top`` and ``_request_ctx_stack.top`` usage.
 
 0.13.0 (2021-05-16)
 ^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Not yet released
 
 - **BREAKING CHANGE**: Drop support for Python 3.6, which reached the end of its life on December 23rd, 2021.
 - **BREAKING CHANGE**: Drop support for SQLAlchemy 1.1, 1.2 and 1.3, which are no longer maintained.
+- Fix ``SAWarning`` from SQLAlchemy 1.4 about missing ``inherit_cache`` attribute
 
 0.13.0 (2021-05-16)
 ^^^^^^^^^^^^^^^^^^^

--- a/postgresql_audit/expressions.py
+++ b/postgresql_audit/expressions.py
@@ -20,6 +20,7 @@ class jsonb_change_key_name(expression.FunctionElement):
     """
     type = JSONB()
     name = 'jsonb_change_key_name'
+    inherit_cache = False
 
 
 @compiles(jsonb_change_key_name)


### PR DESCRIPTION
- Fix the following warning from SQAlchemy 1.4 by setting `inherit_cache =
False`for`jsonb_change_key_name`:

		SAWarning: Class jsonb_change_key_name will not make use of SQL
		compilation caching as it does not set the 'inherit_cache' attribute to
		``True``.  This can have significant performance implications including
		some performance degradations in comparison to prior SQLAlchemy
		versions.  Set this attribute to True if this object can make use of the
		cache key generated by the superclass. Alternatively, this attribute may
		be set to False which will disable this warning. (Background on this
		error at: https://sqlalche.me/e/14/cprf)

- Remove usage of `_app_ctx_stack.top` and `_request_ctx_stack.top` which are deprecated in Flask 2.2.0.