### PR TITLE
Update Flask related test dependencies

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -86,6 +86,10 @@ def user_class(base):
         id = sa.Column(sa.Integer, primary_key=True)
         name = sa.Column(sa.String(100))
         age = sa.Column(sa.Integer)
+
+        def get_id(self):
+            return str(self.id)
+
     return User
 
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,9 +1,9 @@
-Flask-Login==0.2.11
+Flask-Login==0.6.2
 Flask-SQLAlchemy==2.5.1
-Flask==0.10.1
+Flask==2.2.3
 flexmock==0.9.7
-itsdangerous==0.24
-MarkupSafe==0.23
+itsdangerous==2.1.2
+MarkupSafe==2.1.2
 psycopg2>=2.4.6
 pytest>=2.3.5,<3.3.0
-Werkzeug==0.10.1
+Werkzeug==2.2.3


### PR DESCRIPTION
Update Flask related test dependencies to recent versions. A few notes about the changes to the tests:

- Use `flask_login.FlaskLoginClient` introduced in Flask-Login 0.5.0 to log in in the tests.

- In `test_simple_flushing_view`, the expected `client_addr` is now `127.0.0.1` instead of `None` because since Flask 0.12, `app.test_client` includes a preset default environment where `client_addr` is `127.0.0.1`

Fixes #40. Fixes #41.