### PR TITLE
Add support for Flask-SQLAlchemy 3.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Not yet released
 - **BREAKING CHANGE**: Drop support for SQLAlchemy 1.1, 1.2 and 1.3, which are no longer maintained.
 - Fix ``SAWarning`` from SQLAlchemy 1.4 about missing ``inherit_cache`` attribute
 - Fix deprecation warnings from Flask 2.2 about ``_app_ctx_stack.top`` and ``_request_ctx_stack.top`` usage.
+- Add support for Flask-SQLAlchemy 3.0
 
 0.13.0 (2021-05-16)
 ^^^^^^^^^^^^^^^^^^^

--- a/postgresql_audit/base.py
+++ b/postgresql_audit/base.py
@@ -307,7 +307,8 @@ class VersioningManager(object):
             sa.event.listen(*listener)
 
     def set_activity_values(self, session):
-        dialect = session.bind.engine.dialect
+        engine = session.get_bind(self.transaction_cls)
+        dialect = engine.dialect
         table = self.transaction_cls.__table__
 
         if not isinstance(dialect, PGDialect):

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
 Flask-Login==0.6.2
-Flask-SQLAlchemy==2.5.1
+Flask-SQLAlchemy==3.0.3
 Flask==2.2.3
 flexmock==0.9.7
 itsdangerous==2.1.2


### PR DESCRIPTION
`set_activity_values` was crashing on Flask-SQLAlchemy 3.0 due to `session.bind` being `None`.

Fixes #65