### PR TITLE
Fix compatibility with Flask-SQLAlchemy<3.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,32 +30,32 @@ jobs:
           - name: "Python 3.11"
             python: "3.11"
             postgresql-version: 12
-            tox: py-sqla1.4
+            tox: py-sqla1.4-flask-sqla3.0
 
           - name: "Python 3.10"
             python: "3.10"
             postgresql-version: 12
-            tox: py-sqla1.4
+            tox: py-sqla1.4-flask-sqla3.0
 
           - name: "Python 3.9"
             python: "3.9"
             postgresql-version: 12
-            tox: py-sqla1.4
+            tox: py-sqla1.4-flask-sqla3.0
 
           - name: "Python 3.8"
             python: "3.8"
             postgresql-version: 12
-            tox: py-sqla1.4
+            tox: py-sqla1.4-flask-sqla3.0
 
           - name: "Python 3.7"
             python: "3.7"
             postgresql-version: 12
-            tox: py-sqla1.4
+            tox: py-sqla1.4-flask-sqla3.0
 
           - name: "Minimum versions"
             python: "3.7"
             postgresql-version: 9.5
-            tox: py-sqla1.4
+            tox: py-sqla1.4-flask-sqla2.5
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@ Changelog
 
 Here you can see the full list of changes between each PostgreSQL-Audit release.
 
+Not yet released
+^^^^^^^^^^^^^^^^
+
+- Fix compatibility with Flask-SQLAlchemy<3.0
+
 0.14.0 (2023-04-26)
 ^^^^^^^^^^^^^^^^^^^
 

--- a/postgresql_audit/base.py
+++ b/postgresql_audit/base.py
@@ -307,7 +307,8 @@ class VersioningManager(object):
             sa.event.listen(*listener)
 
     def set_activity_values(self, session):
-        engine = session.get_bind(self.transaction_cls)
+        transaction_mapper = sa.inspect(self.transaction_cls)
+        engine = session.get_bind(transaction_mapper)
         dialect = engine.dialect
         table = self.transaction_cls.__table__
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,4 @@
 Flask-Login==0.6.2
-Flask-SQLAlchemy==3.0.3
 Flask==2.2.3
 flexmock==0.9.7
 itsdangerous==2.1.2

--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,15 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = {py37,py38,py39,py310,py311}-sqla{1.4}, lint
+envlist = {py37,py38,py39,py310,py311}-sqla{1.4}-flask-sqla{2.5,3.0}, lint
 
 [testenv]
 commands =
     pytest postgresql_audit tests
 deps =
     -rrequirements_test.txt
+    flask-sqla2.5: Flask-SQLAlchemy==2.5.1
+    flask-sqla3.0: Flask-SQLAlchemy==3.0.3
     sqla1.4: SQLAlchemy>=1.4,<1.5
 passenv =
     POSTGRESQL_AUDIT_TEST_USER


### PR DESCRIPTION
In Flask-SQLAlchemy<3.0, `SignallingSession.get_bind()` crashes when given a model class. Fix the issue by passing it a mapper instance instead.