### PR TITLE
Allow using activity_values in app scope 

### DIFF
--- a/postgresql_audit/flask.py
+++ b/postgresql_audit/flask.py
@@ -13,7 +13,7 @@ class VersioningManager(BaseVersioningManager):
 
     def get_transaction_values(self):
         values = copy(self.values)
-        if has_request_context() and hasattr(g, 'activity_values'):
+        if g and hasattr(g, 'activity_values'):
             values.update(g.activity_values)
         if (
             'client_addr' not in values and
@@ -56,7 +56,8 @@ def merge_dicts(a, b):
 
 @contextmanager
 def activity_values(**values):
-    if not has_request_context():
+    if not g:
+        yield  # Needed for contextmanager
         return
     if hasattr(g, 'activity_values'):
         previous_value = g.activity_values


### PR DESCRIPTION
The request scope is not available in scripts etc.

This removes `current_app.test_request_context()` from something like:
```
from flask import current_app
from postgresql_audit.flask import activity_values
with current_app.test_request_context(), activity_values(some='value'):
    ...
```

Previously, the `activity_values(some='value')` would do nothing if there was no request context.

I also refactored the code to remove `has_request_context`. That is safe as documented by `flask.has_request_context` [documentation](https://flask.palletsprojects.com/en/2.3.x/api/#flask.has_request_context).

`flask.g` is bound to application context ([documentation](https://flask.palletsprojects.com/en/2.3.x/api/#flask.g))