### PR TITLE
style: remove unnecessary future import

### DIFF
--- a/postgresql_audit/flask.py
+++ b/postgresql_audit/flask.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from contextlib import contextmanager
 from copy import copy
 


### PR DESCRIPTION
Absolute imports are the default in Python 3.0.