### PR TITLE
fix: remove unnecessary request context check

### DIFF
--- a/postgresql_audit/flask.py
+++ b/postgresql_audit/flask.py
@@ -31,10 +31,6 @@ class VersioningManager(BaseVersioningManager):
     def default_actor_id(self):
         from flask_login import current_user
 
-        # Return None if we are outside of request context.
-        if not has_request_context():
-            return
-
         try:
             return current_user.id
         except AttributeError:


### PR DESCRIPTION
flask_login.current_user is proxy to None when request context is not set. AttributeError catch handles that case.