### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,13 +47,8 @@ jobs:
             postgresql-version: 12
             tox: py-sqla1.4-flask-sqla3.0
 
-          - name: "Python 3.7"
-            python: "3.7"
-            postgresql-version: 12
-            tox: py-sqla1.4-flask-sqla3.0
-
           - name: "Minimum versions"
-            python: "3.7"
+            python: "3.8"
             postgresql-version: 9.5
             tox: py-sqla1.4-flask-sqla2.5
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,7 +8,6 @@ Supported platforms
 
 PostgreSQL-Audit has been tested against the following Python platforms.
 
-- cPython 3.7
 - cPython 3.8
 - cPython 3.9
 - cPython 3.10

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'SQLAlchemy>=1.4,<1.5',
         'SQLAlchemy-Utils>=0.29.8'
     ],
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
@@ -48,7 +48,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = {py37,py38,py39,py310,py311}-sqla{1.4}-flask-sqla{2.5,3.0}, lint
+envlist = {py38,py39,py310,py311}-sqla{1.4}-flask-sqla{2.5,3.0}, lint
 
 [testenv]
 commands =


### PR DESCRIPTION
Drop support for Python 3.7, which will reach the end of its life on June 27th, 2023. See https://endoflife.date/python.