### PR TITLE
Set SQLALCHEMY_WARN_20=1 in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,8 @@ passenv =
     POSTGRESQL_AUDIT_TEST_USER
     POSTGRESQL_AUDIT_TEST_PASSWORD
     POSTGRESQL_AUDIT_TEST_DB
+setenv =
+    SQLALCHEMY_WARN_20=1
 
 [testenv:lint]
 recreate = True


### PR DESCRIPTION
Set environment variable `SQLALCHEMY_WARN_20=1` to show all SQLAlchemy 2.0 deprecation warnings when running the tests with tox.

Refs #62