### PR TITLE
Fix deprecation warnings about moved declarative extension

### DIFF
--- a/tests/test_custom_schema.py
+++ b/tests/test_custom_schema.py
@@ -2,7 +2,7 @@
 
 import pytest
 import sqlalchemy as sa
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 from postgresql_audit import VersioningManager
 

--- a/tests/test_sqlalchemy_integration.py
+++ b/tests/test_sqlalchemy_integration.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 import pytest
 import sqlalchemy as sa
-from sqlalchemy.ext.declarative import declarative_base, synonym_for
+from sqlalchemy.orm import declarative_base, synonym_for
 
 from postgresql_audit import VersioningManager
 


### PR DESCRIPTION
The `declarative_base()` and `synonym_for()` functions have moved to `sqlalchemy.orm` in SQLAlchemy 2.0.