### PR TITLE
Fix deprecation warning about converting a row to a dict

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,11 +6,9 @@ def last_activity(connection, schema=None):
         schema_prefix = '{}.'.format(schema)
     else:
         schema_prefix = ''
-    return dict(
-        connection.execute(
-            text(
-                'SELECT * FROM {}activity ORDER BY issued_at '
-                'DESC LIMIT 1'.format(schema_prefix)
-            )
-        ).fetchone()
-    )
+    return connection.execute(
+        text(
+            'SELECT * FROM {}activity ORDER BY issued_at '
+            'DESC LIMIT 1'.format(schema_prefix)
+        )
+    ).mappings().fetchone()


### PR DESCRIPTION
This commit fixes the following warning by using the `mappings()` accessor:

    sqlalchemy.exc.RemovedIn20Warning: Using non-integer/slice indices on
    Row is deprecated and will be removed in version 2.0; please use
    row._mapping[<key>], or the mappings() accessor on the Result object.
    (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)

Refs #62