### PR TITLE
Simplify test fixtures

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -47,9 +47,7 @@ def connection(engine):
     with engine.connect() as conn:
         with conn.begin():
             conn.execute(text('CREATE EXTENSION IF NOT EXISTS btree_gist'))
-        
         yield conn
-        conn.close()
 
 
 @pytest.fixture
@@ -62,8 +60,13 @@ def session(connection):
 
 
 @pytest.fixture
-def versioning_manager(base):
-    vm = VersioningManager()
+def schema_name():
+    return None
+
+
+@pytest.fixture
+def versioning_manager(base, schema_name):
+    vm = VersioningManager(schema_name=schema_name)
     vm.init(base)
     yield vm
     vm.remove_listeners()

--- a/tests/test_custom_schema.py
+++ b/tests/test_custom_schema.py
@@ -14,45 +14,6 @@ def schema_name():
     return 'audit'
 
 
-@pytest.fixture
-def versioning_manager(base, schema_name):
-    vm = VersioningManager(schema_name=schema_name)
-    vm.init(base)
-    yield vm
-    vm.remove_listeners()
-
-
-@pytest.fixture
-def activity_cls(versioning_manager):
-    yield versioning_manager.activity_cls
-
-
-@pytest.fixture()
-def table_creator(
-    base,
-    connection,
-    session,
-    models,
-    versioning_manager,
-    schema_name
-):
-    sa.orm.configure_mappers()
-    with connection.begin():
-        connection.execute(
-            sa.text(
-                'DROP SCHEMA IF EXISTS {} CASCADE'.format(schema_name)
-            )
-        )
-        versioning_manager.transaction_cls.__table__.create(connection)
-        versioning_manager.activity_cls.__table__.create(connection)
-        base.metadata.create_all(connection)
-
-    yield
-    session.expunge_all()
-    base.metadata.drop_all(connection)
-    session.commit()
-
-
 @pytest.mark.usefixtures('versioning_manager', 'table_creator')
 class TestCustomSchemaactivityCreation(object):
     def test_insert(self, user, connection, schema_name):

--- a/tests/test_flask_integration.py
+++ b/tests/test_flask_integration.py
@@ -62,11 +62,6 @@ def versioning_manager(db):
 
 
 @pytest.fixture
-def activity_cls(versioning_manager):
-    return versioning_manager.activity_cls
-
-
-@pytest.fixture
 def table_creator(app, db, models, activity_cls, versioning_manager):
     with app.app_context():
         db.configure_mappers()


### PR DESCRIPTION
Drop some extra test fixtures from custom schema and Flask integration tests in favor of reusing the global fixtures.