### PR TITLE
Remove statement caching from VersioningManager.audit_table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Here you can see the full list of changes between each PostgreSQL-Audit release.
 
 - **BREAKING CHANGE**: Drop support for PostgreSQL 9.5, 9.6 and 10, which have reached end of their lives.
 - Remove unused ``VersioningManager.cached_ddls`` attribute
+- Removed redundant statement caching from ``VersioningManager.audit_table``
 
 0.15.0 (2023-05-15)
 ^^^^^^^^^^^^^^^^^^^

--- a/postgresql_audit/base.py
+++ b/postgresql_audit/base.py
@@ -19,7 +19,6 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy_utils import get_class_by_table
 
 HERE = os.path.dirname(os.path.abspath(__file__))
-cached_statements = {}
 
 
 class ImproperlyConfigured(Exception):
@@ -289,9 +288,7 @@ class VersioningManager(object):
         else:
             func = getattr(getattr(sa.func, self.schema_name), 'audit_table')
         query = sa.select(func(*args))
-        if query not in cached_statements:
-            cached_statements[query] = StatementExecutor(query)
-        listener = (table, 'after_create', cached_statements[query])
+        listener = (table, 'after_create', StatementExecutor(query))
         if not sa.event.contains(*listener):
             sa.event.listen(*listener)
 


### PR DESCRIPTION
The caching does not seem to have any effect.