### PR TITLE
Fix statements being autocommitted using implicit autocommit

### DIFF
--- a/tests/test_custom_schema.py
+++ b/tests/test_custom_schema.py
@@ -16,8 +16,9 @@ def schema_name():
 
 @pytest.mark.usefixtures('versioning_manager', 'table_creator')
 class TestCustomSchemaactivityCreation(object):
-    def test_insert(self, user, connection, schema_name):
-        activity = last_activity(connection, schema=schema_name)
+    def test_insert(self, user, engine, schema_name):
+        with engine.begin() as connection:
+            activity = last_activity(connection, schema=schema_name)
         assert activity['old_data'] == {}
         assert activity['changed_data'] == {
             'id': user.id,

--- a/tests/test_sqlalchemy_integration.py
+++ b/tests/test_sqlalchemy_integration.py
@@ -12,8 +12,9 @@ from .utils import last_activity
 
 @pytest.mark.usefixtures('versioning_manager', 'table_creator')
 class TestActivityCreation(object):
-    def test_insert(self, user, connection):
-        activity = last_activity(connection)
+    def test_insert(self, user, engine):
+        with engine.begin() as connection:
+            activity = last_activity(connection)
         assert activity['old_data'] == {}
         assert activity['changed_data'] == {
             'id': user.id,


### PR DESCRIPTION
Fix the following sqlalchemy.exc.RemovedIn20Warning warnings:

    sqlalchemy.exc.RemovedIn20Warning: The current statement is being
    autocommitted using implicit autocommit, which will be removed in
    SQLAlchemy 2.0. Use the .begin() method of Engine or Connection in
    order to use an explicit transaction for DML and DDL statements.
    (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)