### PR TITLE
Enable the `future` flag on Engine

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -36,7 +36,7 @@ def base():
 
 @pytest.fixture
 def engine(dns):
-    engine = create_engine(dns)
+    engine = create_engine(dns, future=True)
     engine.echo = bool(os.environ.get('POSTGRESQL_AUDIT_TEST_ECHO'))
 
     with engine.begin() as conn:


### PR DESCRIPTION
See https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#migration-to-2-0-step-four-use-the-future-flag-on-engine