### PR TITLE
Refactor Audit Table query builder for manual Alembic migration support

### DIFF
--- a/postgresql_audit/base.py
+++ b/postgresql_audit/base.py
@@ -259,7 +259,7 @@ class VersioningManager(object):
             ]
         return listeners
 
-    def audit_table(self, table, exclude_columns=None):
+    def build_audit_table_query(self, table, exclude_columns=None):
         args = [table.name]
         if exclude_columns:
             for column in exclude_columns:
@@ -276,7 +276,12 @@ class VersioningManager(object):
             func = sa.func.audit_table
         else:
             func = getattr(getattr(sa.func, self.schema_name), 'audit_table')
-        query = sa.select(func(*args))
+        return sa.select(func(*args))
+
+    def audit_table(self, table, exclude_columns=None):
+        query = self.build_audit_table_query(
+            table=table, exclude_columns=exclude_columns
+        )
 
         @sa.event.listens_for(table, 'after_create')
         def receive_after_create(target, connection, **kw):


### PR DESCRIPTION
This is a small refactor of the "audit table" query logic, to allow an easy workaround for Alembic migrations.

I've seen many issues/PRs already about a lack of Alembic support, but since they appear to be both complicated and stuck in review, I needed a simpler approach in order to go to production with this library.

This just allows the core audit table query logic to easily be shared by custom Alembic helper functions (not in this PR, but provided as a workaround / example for other developers struggling with Alembic integration):

```
def enable_or_update_model_auditing(op, model):
    """Run PGAudit stored function to enable auditing specific Model.

    This function is designed to be run whenever auditing is enabled or updated (ex: excluded column list is modified).
    """
    from my_auditing import versioning_manager

    assert hasattr(
        model, "__versioned__"
    ), f"Auditing requires `__versioned__` class variable on model `{model}`"

    op.execute(
        versioning_manager.build_audit_table_query(
            model.__table__, model.__versioned__.get("exclude")
        )
    )


def disable_model_auditing(op, model):
    """Disable table-specific auditing machinery. The inverse of `enable_or_update_model_auditing`."""
    tablename = model.__tablename__

    op.execute(f"DROP TRIGGER IF EXISTS audit_trigger_insert ON {tablename}")
    op.execute(f"DROP TRIGGER IF EXISTS audit_trigger_update ON {tablename}")
    op.execute(f"DROP TRIGGER IF EXISTS audit_trigger_delete ON {tablename}")
    op.execute(f"DROP TRIGGER IF EXISTS audit_trigger_row ON {tablename}")
```

Then, I just call either one in my Alembic migration scripts, whenever I add/update/remove auditing configurations:


```
def upgrade():
    from my_models import User

    enable_or_update_model_auditing(op, User)


def downgrade():
    from my_models import User

    disable_model_auditing(op, User)

```