### PR TITLE
Fix deprecated `sqlalchemy.orm.mapper()` usage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Unreleased
 ^^^^^^^^^^
 
 - Use the ``pyproject.toml`` standard to specify project metadata, dependencies and tool configuration. Use Hatch to build the project.
+- Fix a deprecation warning about `sqlalchemy.orm.mapper()` symbol usage on SQLAlchemy 2.0.
 
 0.16.0 (2023-08-04)
 ^^^^^^^^^^^^^^^^^^^

--- a/postgresql_audit/base.py
+++ b/postgresql_audit/base.py
@@ -167,12 +167,12 @@ class VersioningManager(object):
         self.values = {}
         self.listeners = (
             (
-                orm.mapper,
+                orm.Mapper,
                 'instrument_class',
                 self.instrument_versioned_classes
             ),
             (
-                orm.mapper,
+                orm.Mapper,
                 'after_configured',
                 self.configure_versioned_classes
             ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,8 @@ known_first_party = ["postgresql_audit", "tests"]
 line_length       = 79
 multi_line_output = 3
 order_by_type     = false
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    'error:.*:DeprecationWarning:postgresql_audit',
+]


### PR DESCRIPTION
Fix the following deprecation warning on SQLAlchemy 2.0: 

``sqlalchemy.exc.SADeprecationWarning: The `sqlalchemy.orm.mapper()` symbol is deprecated and will be removed in a future release. For the mapper-wide event target, use the 'sqlalchemy.orm.Mapper' class.``