### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,13 +42,8 @@ jobs:
             postgresql-version: 16
             tox: py-max
 
-          - name: "Python 3.8"
-            python: "3.8"
-            postgresql-version: 16
-            tox: py-max
-
           - name: "Minimum versions"
-            python: "3.8"
+            python: "3.9"
             postgresql-version: 13
             tox: py-min
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,12 @@ Changelog
 
 Here you can see the full list of changes between each PostgreSQL-Audit release.
 
+Unreleased
+^^^^^^^^^^
+
+- **BREAKING CHANGE**: Dropped support for Python 3.8.
+
+
 0.18.0 (2026-04-15)
 ^^^^^^^^^^^^^^^^^^^
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,7 +8,6 @@ Supported platforms
 
 PostgreSQL-Audit has been tested against the following Python platforms.
 
-- cPython 3.8
 - cPython 3.9
 - cPython 3.10
 - cPython 3.11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Versioning and auditing extension for PostgreSQL and SQLAlchemy."
 readme = "README.rst"
 license = "bsd-2-clause"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     { name = "Konsta Vesterinen", email = "konsta@fastmonkeys.com" },
 ]
@@ -19,7 +19,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = {py38,py39,py310,py311}-{min,max}, lint
+envlist = {py39,py310,py311}-{min,max}, lint
 
 [testenv]
 commands =


### PR DESCRIPTION
Python 3.8 reached end of life on October 7, 2024.