### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,13 +37,8 @@ jobs:
             postgresql-version: 16
             tox: py-max
 
-          - name: "Python 3.9"
-            python: "3.9"
-            postgresql-version: 16
-            tox: py-max
-
           - name: "Minimum versions"
-            python: "3.9"
+            python: "3.10"
             postgresql-version: 13
             tox: py-min
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Here you can see the full list of changes between each PostgreSQL-Audit release.
 Unreleased
 ^^^^^^^^^^
 
-- **BREAKING CHANGE**: Dropped support for Python 3.8.
+- **BREAKING CHANGE**: Dropped support for Python 3.8 and 3.9.
 
 
 0.18.0 (2026-04-15)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,7 +8,6 @@ Supported platforms
 
 PostgreSQL-Audit has been tested against the following Python platforms.
 
-- cPython 3.9
 - cPython 3.10
 - cPython 3.11
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Versioning and auditing extension for PostgreSQL and SQLAlchemy."
 readme = "README.rst"
 license = "bsd-2-clause"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     { name = "Konsta Vesterinen", email = "konsta@fastmonkeys.com" },
 ]
@@ -19,7 +19,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = {py39,py310,py311}-{min,max}, lint
+envlist = {py310,py311}-{min,max}, lint
 
 [testenv]
 commands =


### PR DESCRIPTION
Python 3.9 reached end of life on October 31, 2025.